### PR TITLE
fix: Set correct Content-Type for all PATCH requests

### DIFF
--- a/jamf/jamfprointegration/headers.go
+++ b/jamf/jamfprointegration/headers.go
@@ -32,8 +32,19 @@ const (
 // - For URL endpoints starting with "/api", it defaults to "application/json" for the JamfPro API.
 // If the endpoint does not match any of the predefined patterns, "application/json" is used as a fallback.
 // This method logs the decision process at various stages for debugging purposes.
-func (j *Integration) getContentTypeHeader(endpoint string) string {
-	j.Sugar.Debug("Determining Content-Type for endpoint", zap.String("endpoint", endpoint))
+func (j *Integration) getContentTypeHeader(endpoint string, method string) string {
+	j.Sugar.Debug("Determining Content-Type for endpoint",
+		zap.String("endpoint", endpoint),
+		zap.String("method", method))
+
+	// Set this header for all PATCH requests
+	// https://developer.jamf.com/developer-guide/docs/api-style-guide#methods
+	if method == "PATCH" {
+		j.Sugar.Debugw("Content-Type for PATCH request set to application/merge-patch+json",
+			"endpoint", endpoint,
+			"method", method)
+		return "application/merge-patch+json"
+	}
 
 	// Set this header for PATCH requests on patch software title configurations
 	if strings.Contains(endpoint, "/api/v2/patch-software-title-configurations/") {

--- a/jamf/jamfprointegration/headers.go
+++ b/jamf/jamfprointegration/headers.go
@@ -46,12 +46,6 @@ func (j *Integration) getContentTypeHeader(endpoint string, method string) strin
 		return "application/merge-patch+json"
 	}
 
-	// Set this header for PATCH requests on patch software title configurations
-	if strings.Contains(endpoint, "/api/v2/patch-software-title-configurations/") {
-		j.Sugar.Debugw("Content-Type for PATCH endpoint set to application/merge-patch+json", "endpoint", endpoint)
-		return "application/merge-patch+json"
-	}
-
 	// TODO change this contains to regex. We want to rule out malformed endpoints with multiple occurances.
 	if strings.Contains(endpoint, "/api/v1/packages/") && strings.Contains(endpoint, "/upload") {
 		j.Sugar.Debugw("Content-Type for packages upload endpoint set to application/octet-stream", "endpoint", endpoint)

--- a/jamf/jamfprointegration/headers_test.go
+++ b/jamf/jamfprointegration/headers_test.go
@@ -62,7 +62,7 @@ func TestIntegration_getContentTypeHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := tt.fields.integration
-			if got := j.getContentTypeHeader(tt.args.endpoint); got != tt.want {
+			if got := j.getContentTypeHeader(tt.args.endpoint, ""); got != tt.want {
 				t.Errorf("Integration.getContentTypeHeader() = %v, want %v", got, tt.want)
 			}
 		})

--- a/jamf/jamfprointegration/preprequest.go
+++ b/jamf/jamfprointegration/preprequest.go
@@ -25,7 +25,7 @@ func (j *Integration) prepRequest(req *http.Request) error {
 
 	j.Sugar.Debugw("LOG-CONTENT-TYPE", "METHOD", req.Method, "URL", req.URL.String())
 	if req.Method != "GET" && req.Method != "DELETE" {
-		req.Header.Add("Content-Type", j.getContentTypeHeader(req.URL.String()))
+		req.Header.Add("Content-Type", j.getContentTypeHeader(req.URL.String(), req.Method))
 	}
 
 	req.Header.Add("Accept", j.getAcceptHeader())


### PR DESCRIPTION
Specified in dev documentation: https://developer.jamf.com/developer-guide/docs/api-style-guide#methods - it should be set for all PATCH requests.

Specifically found that PATCH requests to `/v1/volume-purchasing-locations` fail if not set to `application/merge-patch+json`.

Tested PATCH requests to a few other endpoints and they work with either `application/merge-patch+json` or `application/json`.

However the developer documentation stipulates this is required:

> Standard [PATCH (JSON Merge Patch)](https://tools.ietf.org/html/rfc7386) MUST be used for public Jamf API endpoints.