### PR TITLE
fix: Correct OAuth token endpoint URL in constants

### DIFF
--- a/jamf/jamfprointegration/constants.go
+++ b/jamf/jamfprointegration/constants.go
@@ -5,14 +5,13 @@ import "time"
 // Endpoint constants represent the URL suffixes used for Jamf API token interactions.
 const (
 	// Auth
-	oAuthTokenEndpoint      string = "/api/oauth/token"
+	oAuthTokenEndpoint      string = "/api/v1/oauth/token"
 	bearerTokenEndpoint     string = "/api/v1/auth/token"
 	invalidateTokenEndpoint string = "/api/v1/auth/invalidate-token"
 	keepAliveTokenEndpoint  string = "/api/v1/auth/keep-alive"
 
 	// Load balancer workaround
-	LoadBalancerTargetCookie string = "jpro-ingress"
-	LoadBalancerPollCount    int    = 5
+	LoadBalancerTargetCookie string        = "jpro-ingress"
+	LoadBalancerPollCount    int           = 5
 	LoadBalancerTimeOut      time.Duration = 7 * time.Second
-
 )


### PR DESCRIPTION
Should be using /api/v1/oauth/token and not /api/oauth/token

Per: https://developer.jamf.com/jamf-pro/reference/postoauthtoken