### PR TITLE
feat: add support for Platform Gateway authentication and URL rewriting

### DIFF
--- a/jamf/jamfprointegration/auth_platform_oauth.go
+++ b/jamf/jamfprointegration/auth_platform_oauth.go
@@ -1,0 +1,112 @@
+package jamfprointegration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// platformOAuth implements the authInterface for Jamf platform gateway OAuth2 support.
+// The platform gateway uses a different token endpoint (/auth/token) and returns opaque
+// (non-JWT) bearer tokens. Tokens expire naturally — there is no invalidation endpoint.
+type platformOAuth struct {
+	Sugar             *zap.SugaredLogger
+	gatewayDomain     string
+	clientId          string
+	clientSecret      string
+	bufferPeriod      time.Duration
+	hideSensitiveData bool
+	expiryTime        time.Time
+	token             string
+	http              http.Client
+}
+
+// getNewToken obtains a new access token from the platform gateway auth endpoint.
+func (a *platformOAuth) getNewToken() error {
+	data := url.Values{}
+	data.Set("client_id", a.clientId)
+	data.Set("client_secret", a.clientSecret)
+	data.Set("grant_type", "client_credentials")
+
+	tokenEndpoint := a.gatewayDomain + platformOAuthTokenEndpoint
+	a.Sugar.Debugf("platform oauth endpoint constructed: %s", tokenEndpoint)
+
+	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("bad request getting platform auth token: %v", resp)
+	}
+
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	// Reuse OAuthResponse — the platform gateway returns the same shape (access_token, expires_in)
+	oauthResp := &OAuthResponse{}
+	err = json.Unmarshal(bodyBytes, oauthResp)
+	if err != nil {
+		return fmt.Errorf("failed to decode platform OAuth response: %w", err)
+	}
+
+	if !a.hideSensitiveData {
+		a.Sugar.Debug("platform token received: %+v", oauthResp)
+	}
+
+	if oauthResp.AccessToken == "" {
+		return fmt.Errorf("empty access token received from platform gateway")
+	}
+
+	expiresIn := time.Duration(oauthResp.ExpiresIn) * time.Second
+	a.expiryTime = time.Now().Add(expiresIn)
+	a.token = oauthResp.AccessToken
+
+	a.Sugar.Infow("Platform token obtained successfully", "expiry", a.expiryTime)
+	return nil
+}
+
+// getTokenString returns the current token as a string.
+func (a *platformOAuth) getTokenString() string {
+	return a.token
+}
+
+// getExpiryTime returns the current token's expiry time.
+func (a *platformOAuth) getExpiryTime() time.Time {
+	return a.expiryTime
+}
+
+// tokenExpired returns true if the current token has expired.
+func (a *platformOAuth) tokenExpired() bool {
+	return a.expiryTime.Before(time.Now())
+}
+
+// tokenInBuffer returns true if the token's remaining lifetime is within the buffer period.
+func (a *platformOAuth) tokenInBuffer() bool {
+	return time.Until(a.expiryTime) <= a.bufferPeriod
+}
+
+// tokenEmpty returns true if no token has been obtained yet.
+func (a *platformOAuth) tokenEmpty() bool {
+	return a.token == ""
+}

--- a/jamf/jamfprointegration/builders.go
+++ b/jamf/jamfprointegration/builders.go
@@ -40,14 +40,14 @@ func BuildWithBasicAuth(jamfProFQDN string, Sugar *zap.SugaredLogger, bufferPeri
 
 // BuildWithPlatformGatewayOAuth constructs a Jamf Integration using the platform gateway OAuth2 flow.
 // The gateway URL becomes the base FQDN, and all API paths are rewritten transparently.
-func BuildWithPlatformGatewayOAuth(gatewayURL string, Sugar *zap.SugaredLogger, bufferPeriod time.Duration, clientId string, clientSecret string, scope string, scopeID string, hideSensitiveData bool, client http.Client) (*Integration, error) {
+// The tenantID is the UUID identifying the target Jamf Pro tenant on the platform.
+func BuildWithPlatformGatewayOAuth(gatewayURL string, Sugar *zap.SugaredLogger, bufferPeriod time.Duration, clientId string, clientSecret string, tenantID string, hideSensitiveData bool, client http.Client) (*Integration, error) {
 	integration := Integration{
 		JamfProFQDN:          gatewayURL,
 		Sugar:                Sugar,
 		AuthMethodDescriptor: "platform",
 		http:                 client,
-		Scope:                scope,
-		ScopeID:              scopeID,
+		TenantID:             tenantID,
 	}
 
 	integration.BuildPlatformOAuth(clientId, clientSecret, bufferPeriod, hideSensitiveData, client, gatewayURL)

--- a/jamf/jamfprointegration/builders.go
+++ b/jamf/jamfprointegration/builders.go
@@ -38,6 +38,23 @@ func BuildWithBasicAuth(jamfProFQDN string, Sugar *zap.SugaredLogger, bufferPeri
 	return &integration, err
 }
 
+// BuildWithPlatformGatewayOAuth constructs a Jamf Integration using the platform gateway OAuth2 flow.
+// The gateway URL becomes the base FQDN, and all API paths are rewritten transparently.
+func BuildWithPlatformGatewayOAuth(gatewayURL string, Sugar *zap.SugaredLogger, bufferPeriod time.Duration, clientId string, clientSecret string, tenantID string, hideSensitiveData bool, client http.Client) (*Integration, error) {
+	integration := Integration{
+		JamfProFQDN:          gatewayURL,
+		Sugar:                Sugar,
+		AuthMethodDescriptor: "platform",
+		http:                 client,
+		TenantID:             tenantID,
+	}
+
+	integration.BuildPlatformOAuth(clientId, clientSecret, bufferPeriod, hideSensitiveData, client, gatewayURL)
+	err := integration.CheckRefreshToken()
+
+	return &integration, err
+}
+
 // BuildOAuth is a helper which returns just a configured OAuth interface
 func (j *Integration) BuildOAuth(clientId string, clientSecret string, bufferPeriod time.Duration, hideSensitiveData bool, client http.Client) {
 	authInterface := oauth{
@@ -53,7 +70,7 @@ func (j *Integration) BuildOAuth(clientId string, clientSecret string, bufferPer
 	j.auth = &authInterface
 }
 
-// BuildBasicAuth is a helper which returns just a configured Basic Auth interface/
+// BuildBasicAuth is a helper which returns just a configured Basic Auth interface.
 func (j *Integration) BuildBasicAuth(username string, password string, bufferPeriod time.Duration, hideSensitiveData bool, client http.Client) {
 	authInterface := basicAuth{
 		username:          username,
@@ -61,6 +78,21 @@ func (j *Integration) BuildBasicAuth(username string, password string, bufferPer
 		bufferPeriod:      bufferPeriod,
 		Sugar:             j.Sugar,
 		baseDomain:        j.JamfProFQDN,
+		hideSensitiveData: hideSensitiveData,
+		http:              client,
+	}
+
+	j.auth = &authInterface
+}
+
+// BuildPlatformOAuth is a helper which returns just a configured platform gateway OAuth interface.
+func (j *Integration) BuildPlatformOAuth(clientId string, clientSecret string, bufferPeriod time.Duration, hideSensitiveData bool, client http.Client, gatewayDomain string) {
+	authInterface := platformOAuth{
+		clientId:          clientId,
+		clientSecret:      clientSecret,
+		bufferPeriod:      bufferPeriod,
+		gatewayDomain:     gatewayDomain,
+		Sugar:             j.Sugar,
 		hideSensitiveData: hideSensitiveData,
 		http:              client,
 	}

--- a/jamf/jamfprointegration/builders.go
+++ b/jamf/jamfprointegration/builders.go
@@ -40,13 +40,14 @@ func BuildWithBasicAuth(jamfProFQDN string, Sugar *zap.SugaredLogger, bufferPeri
 
 // BuildWithPlatformGatewayOAuth constructs a Jamf Integration using the platform gateway OAuth2 flow.
 // The gateway URL becomes the base FQDN, and all API paths are rewritten transparently.
-func BuildWithPlatformGatewayOAuth(gatewayURL string, Sugar *zap.SugaredLogger, bufferPeriod time.Duration, clientId string, clientSecret string, tenantID string, hideSensitiveData bool, client http.Client) (*Integration, error) {
+func BuildWithPlatformGatewayOAuth(gatewayURL string, Sugar *zap.SugaredLogger, bufferPeriod time.Duration, clientId string, clientSecret string, scope string, scopeID string, hideSensitiveData bool, client http.Client) (*Integration, error) {
 	integration := Integration{
 		JamfProFQDN:          gatewayURL,
 		Sugar:                Sugar,
 		AuthMethodDescriptor: "platform",
 		http:                 client,
-		TenantID:             tenantID,
+		Scope:                scope,
+		ScopeID:              scopeID,
 	}
 
 	integration.BuildPlatformOAuth(clientId, clientSecret, bufferPeriod, hideSensitiveData, client, gatewayURL)

--- a/jamf/jamfprointegration/constants.go
+++ b/jamf/jamfprointegration/constants.go
@@ -4,11 +4,14 @@ import "time"
 
 // Endpoint constants represent the URL suffixes used for Jamf API token interactions.
 const (
-	// Auth
+	// Auth - direct instance
 	oAuthTokenEndpoint      string = "/api/v1/oauth/token"
 	bearerTokenEndpoint     string = "/api/v1/auth/token"
 	invalidateTokenEndpoint string = "/api/v1/auth/invalidate-token"
 	keepAliveTokenEndpoint  string = "/api/v1/auth/keep-alive"
+
+	// Auth - platform gateway
+	platformOAuthTokenEndpoint string = "/auth/token"
 
 	// Load balancer workaround
 	LoadBalancerTargetCookie string        = "jpro-ingress"

--- a/jamf/jamfprointegration/headers.go
+++ b/jamf/jamfprointegration/headers.go
@@ -56,7 +56,7 @@ func (j *Integration) getContentTypeHeader(endpoint string, method string) strin
 		return "multipart/form-data"
 	}
 
-	if strings.Contains(endpoint, "/JSSResource") {
+	if strings.Contains(endpoint, "/JSSResource") || strings.Contains(endpoint, "/api/proclassic") {
 		j.Sugar.Debugw("Content-Type for endpoint defaulting to XML for Classic API", "endpoint", endpoint)
 		return "application/xml"
 	}

--- a/jamf/jamfprointegration/interfaces.go
+++ b/jamf/jamfprointegration/interfaces.go
@@ -15,8 +15,7 @@ type Integration struct {
 	Sugar                *zap.SugaredLogger
 	auth                 authInterface
 	http                 http.Client
-	Scope                string
-	ScopeID              string
+	TenantID             string
 }
 
 // GetFQDN returns the base FQDN.
@@ -32,17 +31,18 @@ func (j *Integration) ConstructURL(endpoint string) string {
 	return j.GetFQDN() + endpoint
 }
 
-// rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths
-// with the scope and scope ID embedded in the URL path.
-//   /JSSResource/...  to  /api/proclassic/{scope}/{scope_id}/...
-//   /api/v{x}/...     to  /api/pro/{scope}/{scope_id}/v{x}/...
+// rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths.
+// The scope type is always "tenant" for Jamf Classic/Pro APIs under the platform gateway.
+//
+//	/JSSResource/...  →  /api/proclassic/tenant/{tenantID}/...
+//	/api/v{x}/...     →  /api/pro/tenant/{tenantID}/v{x}/...
 func (j *Integration) rewriteEndpointForGateway(endpoint string) string {
 	if strings.HasPrefix(endpoint, "/JSSResource") {
-		return fmt.Sprintf("/api/proclassic/%s/%s%s", j.Scope, j.ScopeID, endpoint[len("/JSSResource"):])
+		return fmt.Sprintf("/api/proclassic/tenant/%s%s", j.TenantID, endpoint[len("/JSSResource"):])
 	}
 
 	if strings.HasPrefix(endpoint, "/api/v") {
-		return fmt.Sprintf("/api/pro/%s/%s%s", j.Scope, j.ScopeID, endpoint[len("/api"):])
+		return fmt.Sprintf("/api/pro/tenant/%s%s", j.TenantID, endpoint[len("/api"):])
 	}
 
 	return endpoint

--- a/jamf/jamfprointegration/interfaces.go
+++ b/jamf/jamfprointegration/interfaces.go
@@ -2,6 +2,7 @@ package jamfprointegration
 
 import (
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -13,6 +14,7 @@ type Integration struct {
 	Sugar                *zap.SugaredLogger
 	auth                 authInterface
 	http                 http.Client
+	TenantID             string // Jamf Pro instance UUID (required for platform gateway auth)
 }
 
 // getFQDN returns just the FQDN // TODO remove the "get"
@@ -20,9 +22,27 @@ func (j *Integration) GetFQDN() string {
 	return j.JamfProFQDN
 }
 
-// constructURL appends any endpoint to the FQDN
+// constructURL appends any endpoint to the FQDN, rewriting paths when in gateway mode.
 func (j *Integration) ConstructURL(endpoint string) string {
+	if j.AuthMethodDescriptor == "platform" {
+		endpoint = j.rewriteEndpointForGateway(endpoint)
+	}
 	return j.GetFQDN() + endpoint
+}
+
+// rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths.
+//   - /JSSResource/... to /api/proclassic/...
+//   - /api/v{x}/...    to /api/pro/v{x}/...
+func (j *Integration) rewriteEndpointForGateway(endpoint string) string {
+	if strings.HasPrefix(endpoint, "/JSSResource") {
+		return strings.Replace(endpoint, "/JSSResource", "/api/proclassic", 1)
+	}
+
+	if strings.HasPrefix(endpoint, "/api/v") {
+		return "/api/pro" + endpoint[len("/api"):]
+	}
+
+	return endpoint
 }
 
 // GetAuthMethodDescriptor returns a single string describing the auth method for debug and logging purposes

--- a/jamf/jamfprointegration/interfaces.go
+++ b/jamf/jamfprointegration/interfaces.go
@@ -35,14 +35,21 @@ func (j *Integration) ConstructURL(endpoint string) string {
 // The scope type is always "tenant" for Jamf Classic/Pro APIs under the platform gateway.
 //
 //	/JSSResource/...  →  /api/proclassic/tenant/{tenantID}/...
-//	/api/v{x}/...     →  /api/pro/tenant/{tenantID}/v{x}/...
+//	/api/v{x}/...     →  /api/pro/v{x}/tenant/{tenantID}/...
 func (j *Integration) rewriteEndpointForGateway(endpoint string) string {
 	if strings.HasPrefix(endpoint, "/JSSResource") {
 		return fmt.Sprintf("/api/proclassic/tenant/%s%s", j.TenantID, endpoint[len("/JSSResource"):])
 	}
 
 	if strings.HasPrefix(endpoint, "/api/v") {
-		return fmt.Sprintf("/api/pro/tenant/%s%s", j.TenantID, endpoint[len("/api"):])
+		rest := endpoint[len("/api/"):]
+		slashIdx := strings.Index(rest, "/")
+		if slashIdx == -1 {
+			return fmt.Sprintf("/api/pro/%s/tenant/%s", rest, j.TenantID)
+		}
+		version := rest[:slashIdx]
+		remainder := rest[slashIdx:]
+		return fmt.Sprintf("/api/pro/%s/tenant/%s%s", version, j.TenantID, remainder)
 	}
 
 	return endpoint

--- a/jamf/jamfprointegration/interfaces.go
+++ b/jamf/jamfprointegration/interfaces.go
@@ -15,15 +15,16 @@ type Integration struct {
 	Sugar                *zap.SugaredLogger
 	auth                 authInterface
 	http                 http.Client
-	TenantID             string // Jamf Pro instance UUID (required for platform gateway auth)
+	Scope                string
+	ScopeID              string
 }
 
-// getFQDN returns just the FQDN // TODO remove the "get"
+// GetFQDN returns the base FQDN.
 func (j *Integration) GetFQDN() string {
 	return j.JamfProFQDN
 }
 
-// constructURL appends any endpoint to the FQDN, rewriting paths when in gateway mode.
+// ConstructURL appends any endpoint to the FQDN, rewriting paths when in gateway mode.
 func (j *Integration) ConstructURL(endpoint string) string {
 	if j.AuthMethodDescriptor == "platform" {
 		endpoint = j.rewriteEndpointForGateway(endpoint)
@@ -32,16 +33,16 @@ func (j *Integration) ConstructURL(endpoint string) string {
 }
 
 // rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths
-// with the tenant ID embedded in the URL path.
-//   - /JSSResource/... → /api/proclassic/tenant/{id}/...
-//   - /api/v{x}/...    → /api/pro/tenant/{id}/v{x}/...
+// with the scope and scope ID embedded in the URL path.
+//   /JSSResource/...  to  /api/proclassic/{scope}/{scope_id}/...
+//   /api/v{x}/...     to  /api/pro/{scope}/{scope_id}/v{x}/...
 func (j *Integration) rewriteEndpointForGateway(endpoint string) string {
 	if strings.HasPrefix(endpoint, "/JSSResource") {
-		return fmt.Sprintf("/api/proclassic/tenant/%s%s", j.TenantID, endpoint[len("/JSSResource"):])
+		return fmt.Sprintf("/api/proclassic/%s/%s%s", j.Scope, j.ScopeID, endpoint[len("/JSSResource"):])
 	}
 
 	if strings.HasPrefix(endpoint, "/api/v") {
-		return fmt.Sprintf("/api/pro/tenant/%s%s", j.TenantID, endpoint[len("/api"):])
+		return fmt.Sprintf("/api/pro/%s/%s%s", j.Scope, j.ScopeID, endpoint[len("/api"):])
 	}
 
 	return endpoint

--- a/jamf/jamfprointegration/interfaces.go
+++ b/jamf/jamfprointegration/interfaces.go
@@ -1,6 +1,7 @@
 package jamfprointegration
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -30,16 +31,17 @@ func (j *Integration) ConstructURL(endpoint string) string {
 	return j.GetFQDN() + endpoint
 }
 
-// rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths.
-//   - /JSSResource/... to /api/proclassic/...
-//   - /api/v{x}/...    to /api/pro/v{x}/...
+// rewriteEndpointForGateway translates direct Jamf Pro API paths to platform gateway paths
+// with the tenant ID embedded in the URL path.
+//   - /JSSResource/... → /api/proclassic/tenant/{id}/...
+//   - /api/v{x}/...    → /api/pro/tenant/{id}/v{x}/...
 func (j *Integration) rewriteEndpointForGateway(endpoint string) string {
 	if strings.HasPrefix(endpoint, "/JSSResource") {
-		return strings.Replace(endpoint, "/JSSResource", "/api/proclassic", 1)
+		return fmt.Sprintf("/api/proclassic/tenant/%s%s", j.TenantID, endpoint[len("/JSSResource"):])
 	}
 
 	if strings.HasPrefix(endpoint, "/api/v") {
-		return "/api/pro" + endpoint[len("/api"):]
+		return fmt.Sprintf("/api/pro/tenant/%s%s", j.TenantID, endpoint[len("/api"):])
 	}
 
 	return endpoint

--- a/jamf/jamfprointegration/marshall.go
+++ b/jamf/jamfprointegration/marshall.go
@@ -41,7 +41,7 @@ func (j *Integration) marshalRequest(body any, _ string, endpoint string) ([]byt
 	)
 
 	format := "json"
-	if strings.Contains(endpoint, "/JSSResource") {
+	if strings.Contains(endpoint, "/JSSResource") || strings.Contains(endpoint, "/api/proclassic") {
 		format = "xml"
 	} else if strings.Contains(endpoint, "/api") {
 		format = "json"

--- a/jamf/jamfprointegration/preprequest.go
+++ b/jamf/jamfprointegration/preprequest.go
@@ -31,6 +31,10 @@ func (j *Integration) prepRequest(req *http.Request) error {
 	req.Header.Add("Accept", j.getAcceptHeader())
 	req.Header.Add("User-Agent", j.getUserAgentHeader())
 
+	if j.AuthMethodDescriptor == "platform" && j.TenantID != "" {
+		req.Header.Add("X-Tenant-Id", j.TenantID)
+	}
+
 	j.Sugar.Debug("request headers added, refreshing token")
 
 	err := j.checkRefreshToken()

--- a/jamf/jamfprointegration/preprequest.go
+++ b/jamf/jamfprointegration/preprequest.go
@@ -31,10 +31,6 @@ func (j *Integration) prepRequest(req *http.Request) error {
 	req.Header.Add("Accept", j.getAcceptHeader())
 	req.Header.Add("User-Agent", j.getUserAgentHeader())
 
-	if j.AuthMethodDescriptor == "platform" && j.TenantID != "" {
-		req.Header.Add("X-Tenant-Id", j.TenantID)
-	}
-
 	j.Sugar.Debug("request headers added, refreshing token")
 
 	err := j.checkRefreshToken()

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,9 @@ This library provides a collection of API integrations utilized by by the [go-ap
 An API integration in this library typically includes the following components:
 
 1. **Authentication Methods**:
-   - **OAuth2.0**: Implements client credentials flow.
+   - **OAuth2.0**: Implements client credentials flow for direct Jamf Pro instance access.
    - **Basic Authentication**: Uses username and password.
+   - **Platform Gateway OAuth2**: Implements client credentials flow via the Jamf platform gateway, with automatic API path rewriting for tenant-scoped access.
    - **Token Management**: Methods to handle token retrieval, expiration checks, and refreshing tokens.
 
 2. **Request Preparation**:
@@ -21,7 +22,9 @@ An API integration in this library typically includes the following components:
     - **Configuration Parameters**: Contextual parameters necessary for setting up the integration. These parameters vary based on the API and the authentication method being used. Examples include:
     - **Microsoft MS Graph**:
        - `clientId`, `clientSecret`, `tenantID`, `bufferPeriod`
-    - **Jamf Pro**:
+    - **Jamf Pro (Direct)**:
        - `clientId`, `clientSecret`, `username`, `password`, `jamfBaseDomain`, `bufferPeriod`
+    - **Jamf Pro (Platform Gateway)**:
+       - `clientId`, `clientSecret`, `gatewayDomain`, `tenantID`, `bufferPeriod`
 
 4. **Shared Utilities**: Common utility functions that are common practise across multiple API integrations.


### PR DESCRIPTION
This adds support for obtaining an access token via the Jamf Platform API Gateway, and then rewriting endpoint URLs for subsequent requests.

When using the Jamf Pro/Classic APIs via the Platform API Gateway, a Tenant ID for the destination Jamf Pro instance is required, and URLs are rewritten as such:

/JSSResource/...  >  /api/proclassic/tenant/{tenantID}/...
/api/v{x}/...     >  /api/pro/v{x}/tenant/{tenantID}/...

This is because a Platform API client credential can have scopes for multiple tenants if the user desires.

Consumers of this project won't need to deal with rewriting URLs - they just need to build the client with the Tenant ID, Gateway URL and credentials.